### PR TITLE
add  method to Noonlight client to override default Sandbox URL

### DIFF
--- a/noonlight/__init__.py
+++ b/noonlight/__init__.py
@@ -243,6 +243,15 @@ class NoonlightClient(object):
         """
         self._token = token
         self._headers['Authorization'] = "Bearer {}".format(self._token)
+
+    def set_base_url(self, base_url):
+        """
+        Override the default Noonlight base url for API calls.
+
+        :param base_url: Base URL for the Noonlight API
+        :type base_url: str
+        """
+        self._base_url = base_url
             
     async def get_alarm_status(self, *, id):
         """

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ View details and usage examples in the `README.md <https://github.com/konnected-
 
 setup(
     name='noonlight',
-    version='0.1.0',
+    version='0.1.1',
     packages=['noonlight'],
     url='https://github.com/konnected-io/noonlight-py',
     license=license,


### PR DESCRIPTION
need to merge this and push to pypi, then update requirements for the noonlight integration in HASS